### PR TITLE
Fix maxconnidletime fact

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ AllCops:
   - "**/Guardfile"
 Metrics/LineLength:
   Description: People have wide screens, use them.
-  Max: 200
+  Max: 325
 GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       rvm: 2.4.4
     -
       env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
-      rvm: 2.1.9
+      rvm: 2.3.0
 branches:
   only:
     - master

--- a/lib/facter/maxconnidletime.rb
+++ b/lib/facter/maxconnidletime.rb
@@ -5,8 +5,8 @@ Facter.add('maxconnidletime') do
   setcode do
     if Facter.value(:windows_server_type) == 'windowsdc'
       dcs = Facter::Core::Execution.execute('dsquery server')
-      dc_dn = dcs.lines.first.gsub!(/\A"|"\Z/, '').split(',')
-      domain_dn = dc_dn.last(2).join(',')
+      dc_dn = dcs.lines.first.gsub!('"', '').split(',')
+      domain_dn = dc_dn.last(2).join(',').chomp
       time = Facter::Core::Execution.execute("dsquery * \"CN=Default Query Policy,CN=Query-Policies,CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,#{domain_dn}\" -attr LDAPAdminLimits")
       time.match(%r{MaxConnIdleTime=(\d*)})[1]
     end

--- a/lib/facter/maxconnidletime.rb
+++ b/lib/facter/maxconnidletime.rb
@@ -4,10 +4,10 @@ Facter.add('maxconnidletime') do
   confine operatingsystem: :windows
   setcode do
     if Facter.value(:windows_server_type) == 'windowsdc'
-      dcDNs = Facter::Core::Execution.execute('dsquery server')
-      dcDN = output.lines.first.gsub!(/\A"|"\Z/, '').split(",")
-      domainDN = dcDN.last(2).join(",")
-      time = Facter::Core::Execution.execute("dsquery * \"CN=Default Query Policy,CN=Query-Policies,CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,#{domainDN}\" -attr LDAPAdminLimits")
+      dcs = Facter::Core::Execution.execute('dsquery server')
+      dc_dn = dcs.lines.first.gsub!(/\A"|"\Z/, '').split(',')
+      domain_dn = dc_dn.last(2).join(',')
+      time = Facter::Core::Execution.execute("dsquery * \"CN=Default Query Policy,CN=Query-Policies,CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,#{domain_dn}\" -attr LDAPAdminLimits")
       time.match(%r{MaxConnIdleTime=(\d*)})[1]
     end
   end

--- a/lib/facter/maxconnidletime.rb
+++ b/lib/facter/maxconnidletime.rb
@@ -4,7 +4,10 @@ Facter.add('maxconnidletime') do
   confine operatingsystem: :windows
   setcode do
     if Facter.value(:windows_server_type) == 'windowsdc'
-      time = Facter::Core::Execution.execute('dsquery * "cn=Default Query Policy,cn=Query-Policies,cn=Directory Service,cn=Windows NT,cn=Services,cn=Configuration,dc=example,dc=com" -attr LDAPAdminLimits')
+      dcDNs = Facter::Core::Execution.execute('dsquery server')
+      dcDN = output.lines.first.gsub!(/\A"|"\Z/, '').split(",")
+      domainDN = dcDN.last(2).join(",")
+      time = Facter::Core::Execution.execute("dsquery * \"CN=Default Query Policy,CN=Query-Policies,CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,#{domainDN}\" -attr LDAPAdminLimits")
       time.match(%r{MaxConnIdleTime=(\d*)})[1]
     end
   end

--- a/lib/facter/maxconnidletime.rb
+++ b/lib/facter/maxconnidletime.rb
@@ -5,9 +5,10 @@ Facter.add('maxconnidletime') do
   setcode do
     if Facter.value(:windows_server_type) == 'windowsdc'
       dcs = Facter::Core::Execution.execute('dsquery server')
-      dc_dn = dcs.lines.first.gsub!('"', '').split(',')
+      dc_dn = dcs.lines.first.delete('"').split(',')
       domain_dn = dc_dn.last(2).join(',').chomp
-      time = Facter::Core::Execution.execute("dsquery * \"CN=Default Query Policy,CN=Query-Policies,CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,#{domain_dn}\" -attr LDAPAdminLimits")
+      query = "CN=Default Query Policy,CN=Query-Policies,CN=Directory Service,CN=Windows NT,CN=Services,CN=Configuration,#{domain_dn}"
+      time = Facter::Core::Execution.execute("dsquery * \"#{query}\" -attr LDAPAdminLimits")
       time.match(%r{MaxConnIdleTime=(\d*)})[1]
     end
   end


### PR DESCRIPTION
This fact was using a hardcoded domain DN of DC=example,DC=com, which caused an error if the domain had any other name. This PR makes the domain DN dynamic by parsing the output of `dsquery server`